### PR TITLE
fix: url de imágenes en el carrito cuando se accede con / al final

### DIFF
--- a/src/views/cart.ejs
+++ b/src/views/cart.ejs
@@ -63,7 +63,7 @@
       <div class="detailsWrapper">
         <section class="product">
           <article class="singleProductWrapper">
-            <img src="images/ropa-deportiva/bandas.png" alt="" />
+            <img src="/images/ropa-deportiva/bandas.png" alt="" />
             <div>
               <p>Set de bandas elasticas</p>
               <form class="add">
@@ -80,7 +80,7 @@
             <p>$60.000</p>
           </article>
           <article class="singleProductWrapper">
-            <img src="images/ropa-deportiva/conjunto.png" alt="" />
+            <img src="/images/ropa-deportiva/conjunto.png" alt="" />
             <div>
               <p>Conjunto deportivo</p>
               <form class="add">
@@ -130,13 +130,13 @@
       <h2>Visto recientemente</h2>
       <section class="recentView">
         <div class="products">
-          <img class="imgProducts" src="images/ropa-deportiva/bascula.jpeg" alt="products bascula">
+          <img class="imgProducts" src="/images/ropa-deportiva/bascula.jpeg" alt="products bascula">
           <p>Bascula Digital</p>
           <p>$68.000</p>
         </div>
 
         <div class="products">
-          <img class="imgProducts" src="images/ropa-deportiva/colchoneta-yoga.jpg" alt="products colchoneta-yoga">
+          <img class="imgProducts" src="/images/ropa-deportiva/colchoneta-yoga.jpg" alt="products colchoneta-yoga">
           <p>Mat de Yoga Doble Fax</p>
           <p>$72.000</p>
         </div>


### PR DESCRIPTION
## Description

Cuando se accede al carrito con un `/` al final de la url algunas imágenes no cargan.

## Screenshots

Antes: 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/113132734/211447096-98adcff1-fa44-4e2f-bde9-d9b4e4df5118.png">

Después:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/113132734/211447169-fd9b24bf-4c84-4d06-b43d-df2e66816b06.png">
